### PR TITLE
Fix: Allow installation of `rector/rector:~0.19.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.0.0...main`][1.0.0...main].
 
+### Changed
+
+- Allowed installation of `rector/rector:~0.19.2` ([#77]), by [@localheinz]
+
 ## [`1.0.0`][1.0.0]
 
 For a full diff see [`0.4.0...1.0.0`][0.4.0...1.0.0].
@@ -75,5 +79,6 @@ For a full diff see [`fd198f0...0.1.0`][fd198f0...0.1.0].
 [#64]: https://github.com/ergebnis/rector-rules/pull/64
 [#65]: https://github.com/ergebnis/rector-rules/pull/65
 [#76]: https://github.com/ergebnis/rector-rules/pull/76
+[#77]: https://github.com/ergebnis/rector-rules/pull/77
 
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
     "nikic/php-parser": "^4.17.1 || ^5.0.0",
     "phpstan/phpstan": "^1.10.36",
-    "rector/rector": "^1.0.0",
+    "rector/rector": "~0.19.2 || ^1.0.0",
     "symplify/rule-doc-generator-contracts": "^9.3.26"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da1e90794a2a74bce868b06ce849b309",
+    "content-hash": "992cfa5ff99f23d3af72d4d508b6d887",
     "packages": [
         {
             "name": "danielstjules/stringy",


### PR DESCRIPTION
This pull request

- [x] allows installation of `rector/rector:~0.19.2`

Follows #76.