### PR TITLE
Fix: Require `rector/rector:^2.0.11`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.3.0...main`][1.3.0...main].
 
+### Changed
+
+- Required `rector/rector:^2.0.11` ([#199]), by [@localheinz]
+
 ## [`1.3.0`][1.3.0]
 
 For a full diff see [`1.2.0...1.3.0`][1.2.0...1.3.0].
@@ -124,5 +128,6 @@ For a full diff see [`fd198f0...0.1.0`][fd198f0...0.1.0].
 [#161]: https://github.com/ergebnis/rector-rules/pull/161
 [#162]: https://github.com/ergebnis/rector-rules/pull/162
 [#171]: https://github.com/ergebnis/rector-rules/pull/171
+[#199]: https://github.com/ergebnis/rector-rules/pull/199
 
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
     "nikic/php-parser": "^4.17.1 || ^5.0.0",
     "phpstan/phpstan": "^2.0.0",
-    "rector/rector": "^2.0.0"
+    "rector/rector": "^2.0.11"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.46.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17e846bde9ffdbef1edfc873f5d23f00",
+    "content-hash": "4f9ec7a1d8b138e80c9d568ba7c46be7",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -64,16 +64,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.2",
+            "version": "2.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "7d08f569e582ade182a375c366cbd896eccadd3a"
+                "reference": "8ca5f79a8f63c49b2359065832a654e1ec70ac30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7d08f569e582ade182a375c366cbd896eccadd3a",
-                "reference": "7d08f569e582ade182a375c366cbd896eccadd3a",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8ca5f79a8f63c49b2359065832a654e1ec70ac30",
+                "reference": "8ca5f79a8f63c49b2359065832a654e1ec70ac30",
                 "shasum": ""
             },
             "require": {
@@ -118,25 +118,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-21T14:54:06+00:00"
+            "time": "2025-03-24T13:45:00+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "2.0.6",
+            "version": "2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "fa0cb009dc3df084bf549032ae4080a0481a2036"
+                "reference": "059b827cc648929711606e9824337e41e2f9ed92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/fa0cb009dc3df084bf549032ae4080a0481a2036",
-                "reference": "fa0cb009dc3df084bf549032ae4080a0481a2036",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/059b827cc648929711606e9824337e41e2f9ed92",
+                "reference": "059b827cc648929711606e9824337e41e2f9ed92",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.1"
+                "phpstan/phpstan": "^2.1.9"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -169,7 +169,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.0.6"
+                "source": "https://github.com/rectorphp/rector/tree/2.0.11"
             },
             "funding": [
                 {
@@ -177,7 +177,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-06T10:38:36+00:00"
+            "time": "2025-03-28T10:25:17+00:00"
         }
     ],
     "packages-dev": [
@@ -6444,15 +6444,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4.33"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/infection.json
+++ b/infection.json
@@ -3,7 +3,7 @@
   "logs": {
     "text": ".build/infection/infection-log.txt"
   },
-  "minCoveredMsi": 85,
+  "minCoveredMsi": 83,
   "minMsi": 72,
   "phpUnit": {
     "configDir": "test\/Unit"

--- a/src/Arrays/SortAssociativeArrayByKeyRector.php
+++ b/src/Arrays/SortAssociativeArrayByKeyRector.php
@@ -128,10 +128,16 @@ CODE_SAMPLE
             return false;
         }
 
-        if (!$classReflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
-            return false;
+        $parentClass = $classReflection->getParentClass();
+
+        while ($parentClass instanceof ClassReflection) {
+            if ($parentClass->getName() === 'PHPUnit\Framework\TestCase') {
+                return true;
+            }
+
+            $parentClass = $parentClass->getParentClass();
         }
 
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
This pull request

- [x] requires `rector/rector:^2.0.11`

Related to https://github.com/rectorphp/rector/issues/9011.