### PR TITLE
Fix: Do not override default value for `comparison_function` with unexpected value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`1.5.0...main`][1.5.0...main].
 ### Fixed
 
 - Removed an unnecessary condition in `Rules\Arrays\SortAssociativeArrayByKeyRector` ([#210]), by [@localheinz]
+- Reverted back to using `strcmp` as default comparison function in `Rules\Arrays\SortAssociativeArrayByKeyRector` ([#216]), by [@localheinz]
 
 ## [`1.5.0`][1.5.0]
 
@@ -152,5 +153,6 @@ For a full diff see [`fd198f0...0.1.0`][fd198f0...0.1.0].
 [#199]: https://github.com/ergebnis/rector-rules/pull/199
 [#200]: https://github.com/ergebnis/rector-rules/pull/200
 [#210]: https://github.com/ergebnis/rector-rules/pull/210
+[#216]: https://github.com/ergebnis/rector-rules/pull/216
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Arrays/SortAssociativeArrayByKeyRector.php
+++ b/src/Arrays/SortAssociativeArrayByKeyRector.php
@@ -40,10 +40,7 @@ final class SortAssociativeArrayByKeyRector extends Rector\AbstractRector implem
 
     public function __construct()
     {
-        $this->configure([
-            self::CONFIGURATION_KEY_COMPARISON_FUNCTION => 'strcasecmp',
-            self::CONFIGURATION_KEY_DIRECTION => 'asc',
-        ]);
+        $this->configure([]);
     }
 
     public function getRuleDefinition(): RuleDocGenerator\ValueObject\RuleDefinition

--- a/test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php74/file.php.inc
+++ b/test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php74/file.php.inc
@@ -27,13 +27,13 @@ namespace Ergebnis\Rector\Rules\Test\Fixture\Arrays\SortAssociativeArrayByKeyRec
 
 $data = [
     'bar' => [
-        'quux' => 'quuz',
+        'QuZ' => 'qux',
         'Quux' => 'quuz',
         'Quz' => 'qux',
-        'QuZ' => 'qux',
-        'quz' => 'qux',
         'Quz10' => 'qux',
         'Quz2' => 'qux',
+        'quux' => 'quuz',
+        'quz' => 'qux',
     ],
     'foo' => [
         'foo',

--- a/test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php74/rules.php.inc
+++ b/test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php74/rules.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Ergebnis\Rector\Rules\Test\Fixture\Arrays\SortAssociativeArrayByKeyRector\WithDefaultConfiguration\Php74;
+
+return [
+    'ErickSkrauch/line_break_after_statements' => true,
+    'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+    'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+        'ignore_expressions' => true,
+    ],
+    'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+    'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
+    'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
+    'PhpCsFixerCustomFixers/typed_class_constant' => true,
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+        'operators' => [],
+    ],
+    'blank_line_between_import_groups' => false,
+    'blank_lines_before_namespace' => [
+        'max_line_breaks' => 2,
+        'min_line_breaks' => 2,
+    ],
+];
+
+?>
+-----
+<?php
+
+namespace Ergebnis\Rector\Rules\Test\Fixture\Arrays\SortAssociativeArrayByKeyRector\WithDefaultConfiguration\Php74;
+
+return [
+    'ErickSkrauch/line_break_after_statements' => true,
+    'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+    'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+        'ignore_expressions' => true,
+    ],
+    'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+    'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
+    'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
+    'PhpCsFixerCustomFixers/typed_class_constant' => true,
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+        'operators' => [],
+    ],
+    'blank_line_between_import_groups' => false,
+    'blank_lines_before_namespace' => [
+        'max_line_breaks' => 2,
+        'min_line_breaks' => 2,
+    ],
+];
+
+?>

--- a/test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php80/file.php.inc
+++ b/test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php80/file.php.inc
@@ -27,13 +27,13 @@ namespace Ergebnis\Rector\Rules\Test\Fixture\Arrays\SortAssociativeArrayByKeyRec
 
 $data = [
     'bar' => [
-        'Quux' => 'quuz',
-        'quux' => 'quuz',
-        'Quz' => 'qux',
         'QuZ' => 'qux',
-        'quz' => 'qux',
+        'Quux' => 'quuz',
+        'Quz' => 'qux',
         'Quz10' => 'qux',
         'Quz2' => 'qux',
+        'quux' => 'quuz',
+        'quz' => 'qux',
     ],
     'foo' => [
         'foo',

--- a/test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php80/rules.php.inc
+++ b/test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php80/rules.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Ergebnis\Rector\Rules\Test\Fixture\Arrays\SortAssociativeArrayByKeyRector\WithDefaultConfiguration\Php80;
+
+return [
+    'ErickSkrauch/line_break_after_statements' => true,
+    'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+    'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+        'ignore_expressions' => true,
+    ],
+    'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+    'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
+    'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
+    'PhpCsFixerCustomFixers/typed_class_constant' => true,
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+        'operators' => [],
+    ],
+    'blank_line_between_import_groups' => false,
+    'blank_lines_before_namespace' => [
+        'max_line_breaks' => 2,
+        'min_line_breaks' => 2,
+    ],
+];
+
+?>
+-----
+<?php
+
+namespace Ergebnis\Rector\Rules\Test\Fixture\Arrays\SortAssociativeArrayByKeyRector\WithDefaultConfiguration\Php80;
+
+return [
+    'ErickSkrauch/line_break_after_statements' => true,
+    'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+    'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+        'ignore_expressions' => true,
+    ],
+    'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+    'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
+    'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
+    'PhpCsFixerCustomFixers/typed_class_constant' => true,
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+        'operators' => [],
+    ],
+    'blank_line_between_import_groups' => false,
+    'blank_lines_before_namespace' => [
+        'max_line_breaks' => 2,
+        'min_line_breaks' => 2,
+    ],
+];
+
+?>


### PR DESCRIPTION
This pull request

- [x] adds a test case to document a regression
- [x] stops overriding the default value for the `comparison_function` option with an unexpected value

Follows #173.