### PR TITLE
Fix: Adjust `Files\ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector` to skip references to constants and functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For a full diff see [`1.15.2...main`][1.15.2...main].
 
 - Added `Rules\Expressions\Matches\SortMatchArmsByConditionalRector` ([#333]), by [@localheinz]
 
+### Fixed
+
+- Adjusted `Rules\Files\ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector` to skip fully-qualified function calls and constant references ([#334]), by [@localheinz]
+
 ## [`1.15.2`][1.15.2]
 
 For a full diff see [`1.15.1...1.15.2`][1.15.1...1.15.2].
@@ -422,5 +426,6 @@ For a full diff see [`fd198f0...0.1.0`][fd198f0...0.1.0].
 [#326]: https://github.com/ergebnis/rector-rules/pull/326
 [#327]: https://github.com/ergebnis/rector-rules/pull/327
 [#333]: https://github.com/ergebnis/rector-rules/pull/333
+[#334]: https://github.com/ergebnis/rector-rules/pull/334
 
 [@localheinz]: https://github.com/localheinz

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,6 +49,12 @@ parameters:
 			path: src/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector.php
 
 		-
+			message: '#^Parameter \#1 \$statements of static method Ergebnis\\Rector\\Rules\\Files\\ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector\:\:functionAndConstantNodeIdentifiers\(\) expects list\<PhpParser\\Node\\Stmt\>, array\<PhpParser\\Node\\Stmt\> given\.$#'
+			identifier: argument.type
+			count: 5
+			path: src/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector.php
+
+		-
 			message: '#^Parameter \#1 \$node \(Rector\\PhpParser\\Node\\FileNode\) of method Ergebnis\\Rector\\Rules\\Files\\UseImportRelativeToNamespacePrefixRector\:\:refactor\(\) should be contravariant with parameter \$node \(PhpParser\\Node\) of method Rector\\Contract\\Rector\\RectorInterface\:\:refactor\(\)$#'
 			identifier: method.childParameterType
 			count: 3

--- a/src/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector.php
+++ b/src/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector.php
@@ -665,6 +665,13 @@ CODE_SAMPLE
     ): bool {
         foreach ($containerNode->stmts as $statement) {
             if ($statement instanceof Node\Stmt\Use_) {
+                if (
+                    Node\Stmt\Use_::TYPE_FUNCTION === $statement->type
+                    || Node\Stmt\Use_::TYPE_CONSTANT === $statement->type
+                ) {
+                    continue;
+                }
+
                 foreach ($statement->uses as $use) {
                     $reference = Rules\Files\Reference::fromString($use->name->toString());
 
@@ -677,6 +684,13 @@ CODE_SAMPLE
                     }
                 }
             } elseif ($statement instanceof Node\Stmt\GroupUse) {
+                if (
+                    Node\Stmt\Use_::TYPE_FUNCTION === $statement->type
+                    || Node\Stmt\Use_::TYPE_CONSTANT === $statement->type
+                ) {
+                    continue;
+                }
+
                 $prefix = $statement->prefix->toString();
 
                 foreach ($statement->uses as $use) {
@@ -755,10 +769,16 @@ CODE_SAMPLE
     ): bool {
         $nodeFinder = new NodeFinder();
 
+        $functionAndConstantNodeIdentifiers = self::functionAndConstantNodeIdentifiers($containerNode->stmts);
+
         $match = $nodeFinder->findFirst(
             $containerNode->stmts,
-            static function (Node $node) use ($namespacePrefix, $moreSpecificNamespacePrefixes): bool {
+            static function (Node $node) use ($namespacePrefix, $moreSpecificNamespacePrefixes, $functionAndConstantNodeIdentifiers): bool {
                 if (!$node instanceof Node\Name\FullyQualified) {
+                    return false;
+                }
+
+                if (\in_array(\spl_object_id($node), $functionAndConstantNodeIdentifiers, true)) {
                     return false;
                 }
 
@@ -814,10 +834,16 @@ CODE_SAMPLE
     ): bool {
         $nodeFinder = new NodeFinder();
 
+        $functionAndConstantNodeIdentifiers = self::functionAndConstantNodeIdentifiers($containerNode->stmts);
+
         $match = $nodeFinder->findFirst(
             $containerNode->stmts,
-            static function (Node $node) use ($namespacePrefix, $moreSpecificNamespacePrefixes): bool {
+            static function (Node $node) use ($namespacePrefix, $moreSpecificNamespacePrefixes, $functionAndConstantNodeIdentifiers): bool {
                 if (!$node instanceof Node\Name\FullyQualified) {
+                    return false;
+                }
+
+                if (\in_array(\spl_object_id($node), $functionAndConstantNodeIdentifiers, true)) {
                     return false;
                 }
 
@@ -911,8 +937,14 @@ CODE_SAMPLE
 
         $hasChanged = false;
 
-        $this->traverseNodesWithCallable($containerNode->stmts, static function (Node $node) use ($namespacePrefix, $lastNamespaceSegmentOfNamespacePrefix, $moreSpecificNamespacePrefixes, $namespacePrefixOfContainingFile, &$hasChanged): ?Node {
+        $functionAndConstantNodeIdentifiers = self::functionAndConstantNodeIdentifiers($containerNode->stmts);
+
+        $this->traverseNodesWithCallable($containerNode->stmts, static function (Node $node) use ($namespacePrefix, $lastNamespaceSegmentOfNamespacePrefix, $moreSpecificNamespacePrefixes, $namespacePrefixOfContainingFile, $functionAndConstantNodeIdentifiers, &$hasChanged): ?Node {
             if (!$node instanceof Node\Name\FullyQualified) {
+                return null;
+            }
+
+            if (\in_array(\spl_object_id($node), $functionAndConstantNodeIdentifiers, true)) {
                 return null;
             }
 
@@ -1355,10 +1387,16 @@ CODE_SAMPLE
 
         $nodeFinder = new NodeFinder();
 
+        $functionAndConstantNodeIdentifiers = self::functionAndConstantNodeIdentifiers($containerNode->stmts);
+
         $nodeFinder->find(
             $containerNode->stmts,
-            static function (Node $node) use ($collectFirstSegment): bool {
+            static function (Node $node) use ($collectFirstSegment, $functionAndConstantNodeIdentifiers): bool {
                 if (!$node instanceof Node\Name\FullyQualified) {
+                    return false;
+                }
+
+                if (\in_array(\spl_object_id($node), $functionAndConstantNodeIdentifiers, true)) {
                     return false;
                 }
 
@@ -1497,10 +1535,16 @@ CODE_SAMPLE
 
         $nodeFinder = new NodeFinder();
 
+        $functionAndConstantNodeIdentifiers = self::functionAndConstantNodeIdentifiers($containerNode->stmts);
+
         $nodeFinder->find(
             $containerNode->stmts,
-            static function (Node $node) use ($parentNamespacePrefixes, &$existingKeys, &$discoveredNamespacePrefixes): bool {
+            static function (Node $node) use ($parentNamespacePrefixes, &$existingKeys, &$discoveredNamespacePrefixes, $functionAndConstantNodeIdentifiers): bool {
                 if (!$node instanceof Node\Name\FullyQualified) {
+                    return false;
+                }
+
+                if (\in_array(\spl_object_id($node), $functionAndConstantNodeIdentifiers, true)) {
                     return false;
                 }
 
@@ -1584,6 +1628,39 @@ CODE_SAMPLE
     }
 
     /**
+     * @param list<Node\Stmt> $statements
+     *
+     * @return list<int>
+     */
+    private static function functionAndConstantNodeIdentifiers(array $statements): array
+    {
+        $nodeFinder = new NodeFinder();
+
+        $nodes = $nodeFinder->find($statements, static function (Node $node): bool {
+            if (
+                $node instanceof Node\Expr\ConstFetch
+                && $node->name instanceof Node\Name\FullyQualified
+            ) {
+                return true;
+            }
+
+            if (
+                $node instanceof Node\Expr\FuncCall
+                && $node->name instanceof Node\Name\FullyQualified
+            ) {
+                return true;
+            }
+
+            return false;
+        });
+
+        return \array_values(\array_unique(\array_map(static function (Node $node): int {
+            /** @var Node\Expr\ConstFetch|Node\Expr\FuncCall $node */
+            return \spl_object_id($node->name);
+        }, $nodes)));
+    }
+
+    /**
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
      * @param list<NamespacePrefix>                        $moreSpecificNamespacePrefixes
      */
@@ -1602,6 +1679,13 @@ CODE_SAMPLE
 
         foreach ($containerNode->stmts as $index => $stmt) {
             if ($stmt instanceof Node\Stmt\Use_) {
+                if (
+                    Node\Stmt\Use_::TYPE_FUNCTION === $stmt->type
+                    || Node\Stmt\Use_::TYPE_CONSTANT === $stmt->type
+                ) {
+                    continue;
+                }
+
                 $remainingUses = [];
 
                 foreach ($stmt->uses as $use) {
@@ -1639,6 +1723,13 @@ CODE_SAMPLE
                     $stmt->uses = $remainingUses;
                 }
             } elseif ($stmt instanceof Node\Stmt\GroupUse) {
+                if (
+                    Node\Stmt\Use_::TYPE_FUNCTION === $stmt->type
+                    || Node\Stmt\Use_::TYPE_CONSTANT === $stmt->type
+                ) {
+                    continue;
+                }
+
                 $prefix = $stmt->prefix->toString();
 
                 $remainingUses = [];

--- a/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithDiscoverNamespacePrefixes/fully-qualified-constant-reference-is-not-rewritten.php.inc
+++ b/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithDiscoverNamespacePrefixes/fully-qualified-constant-reference-is-not-rewritten.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace App;
+
+final class Kernel
+{
+    public function handle()
+    {
+        $value = \Foo\Bar\SOME_CONSTANT;
+    }
+}
+
+?>

--- a/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithDiscoverNamespacePrefixes/fully-qualified-function-call-is-not-rewritten.php.inc
+++ b/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithDiscoverNamespacePrefixes/fully-qualified-function-call-is-not-rewritten.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace App;
+
+final class Kernel
+{
+    public function handle()
+    {
+        \Safe\unlink('/tmp/file.txt');
+        \Safe\file_get_contents('/tmp/file.txt');
+    }
+}
+
+?>

--- a/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithNamespacePrefixes/Php70/file-is-in-child-namespace-of-prefix.php.inc
+++ b/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithNamespacePrefixes/Php70/file-is-in-child-namespace-of-prefix.php.inc
@@ -123,6 +123,8 @@ final class ListAction extends AbstractAction implements Arrayable, Jsonable
 namespace App\Controller\User;
 
 use App\Controller;
+use function App\Controller\Helper\resolve_path;
+use const App\Controller\Config\DEFAULT_TIMEOUT;
 use Other\Foo\Repository\DepartmentRepository;
 use Psr\Http\Message\ResponseInterface;
 
@@ -170,8 +172,8 @@ final class ListAction extends Controller\AbstractAction implements Controller\C
         $obj,
         $fqn
     ): ResponseInterface {
-        $path = Controller\Helper\resolve_path('/users');
-        $timeout = Controller\Config\DEFAULT_TIMEOUT;
+        $path = resolve_path('/users');
+        $timeout = DEFAULT_TIMEOUT;
 
         $class = Controller\Event\UserEvent::class;
         $middleware = new Controller\Middleware\AuthMiddleware();

--- a/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithNamespacePrefixes/Php85/file-is-in-child-namespace-of-prefix.php.inc
+++ b/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithNamespacePrefixes/Php85/file-is-in-child-namespace-of-prefix.php.inc
@@ -45,6 +45,7 @@ final class EditAction
 namespace App\Controller\User;
 
 use App\Controller;
+use function App\Controller\Helper\resolve_path;
 use Psr\Http\Message\ResponseInterface;
 
 final class EditAction
@@ -64,7 +65,7 @@ final class EditAction
     )]
     public function __invoke(string $id): Controller\DashboardAction|ResponseInterface
     {
-        $result = $id |> Controller\Helper\resolve_path(...);
+        $result = $id |> resolve_path(...);
 
         $clone = clone($this->dashboard, []);
 

--- a/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithParentNamespacePrefixes/fully-qualified-constant-reference-is-not-rewritten.php.inc
+++ b/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithParentNamespacePrefixes/fully-qualified-constant-reference-is-not-rewritten.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace App;
+
+use Symfony\Component\HttpFoundation\Response;
+
+final class Kernel
+{
+    public function handle(): Response
+    {
+        $value = \Foo\Bar\SOME_CONSTANT;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace App;
+
+use Symfony\Component\HttpFoundation;
+
+final class Kernel
+{
+    public function handle(): HttpFoundation\Response
+    {
+        $value = \Foo\Bar\SOME_CONSTANT;
+    }
+}
+
+?>

--- a/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithParentNamespacePrefixes/fully-qualified-function-call-is-not-rewritten.php.inc
+++ b/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithParentNamespacePrefixes/fully-qualified-function-call-is-not-rewritten.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace App;
+
+use Symfony\Component\HttpFoundation\Response;
+
+final class Kernel
+{
+    public function handle(): Response
+    {
+        \Safe\unlink('/tmp/file.txt');
+        \Safe\file_get_contents('/tmp/file.txt');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace App;
+
+use Symfony\Component\HttpFoundation;
+
+final class Kernel
+{
+    public function handle(): HttpFoundation\Response
+    {
+        \Safe\unlink('/tmp/file.txt');
+        \Safe\file_get_contents('/tmp/file.txt');
+    }
+}
+
+?>


### PR DESCRIPTION
This pull request

- [x] adjusts `Files\ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector` to skip references to constants and functions