### PR TITLE
Fix: Deprecate `Arrays\SortAssociativeArrayByKeyRector` in favor of `Expressions\Arrays\SortAssociativeArrayByKeyRector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For a full diff see [`1.15.2...main`][1.15.2...main].
 
 - Added `Rules\Expressions\Matches\SortMatchArmsByConditionalRector` ([#333]), by [@localheinz]
 
+### Deprecated
+
+- Deprecated `Arrays\SortAssociativeArrayByKeyRector` in favor of `Expressions\Arrays\SortAssociativeArrayByKeyRector` ([#335]), by [@localheinz]
+
 ### Fixed
 
 - Adjusted `Rules\Files\ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector` to skip fully-qualified function calls and constant references ([#334]), by [@localheinz]
@@ -427,5 +431,6 @@ For a full diff see [`fd198f0...0.1.0`][fd198f0...0.1.0].
 [#327]: https://github.com/ergebnis/rector-rules/pull/327
 [#333]: https://github.com/ergebnis/rector-rules/pull/333
 [#334]: https://github.com/ergebnis/rector-rules/pull/334
+[#335]: https://github.com/ergebnis/rector-rules/pull/335
 
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ composer require --dev ergebnis/rector-rules
 
 This project provides the following rules for [`rector/rector`](https://github.com/rectorphp/rector):
 
-- [`Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector`](#arrayssortassociativearraybykeyrector)
+- [`Ergebnis\Rector\Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector`](#expressionsarrayssortassociativearraybykeyrector)
 - [`Ergebnis\Rector\Rules\Expressions\Matches\SortMatchArmsByConditionalRector`](#expressionsmatchessortmatcharmsbyconditionalrector)
 - [`Ergebnis\Rector\Rules\Faker\GeneratorPropertyFetchToMethodCallRector`](#fakergeneratorpropertyfetchtomethodcallrector)
 - [`Ergebnis\Rector\Rules\Files\ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector`](#filesreferencenamespacedsymbolsrelativetonamespaceprefixrector)
 
-### Arrays
+### Expressions\Arrays
 
-#### `Arrays\SortAssociativeArrayByKeyRector`
+#### `Expressions\Arrays\SortAssociativeArrayByKeyRector`
 
 Sorts associative arrays by key.
 
@@ -56,7 +56,7 @@ Sorts associative arrays by key.
  ];
 ```
 
-💡 Find out more in the rule documentation for [`Arrays\SortAssociativeArrayByKeyRector`](doc/rules/Arrays/SortAssociativeArrayByKeyRector.md).
+💡 Find out more in the rule documentation for [`Expressions\Arrays\SortAssociativeArrayByKeyRector`](doc/rules/Expressions/Arrays/SortAssociativeArrayByKeyRector.md).
 
 ### Expressions\Matches
 

--- a/doc/rules/Expressions/Arrays/SortAssociativeArrayByKeyRector.md
+++ b/doc/rules/Expressions/Arrays/SortAssociativeArrayByKeyRector.md
@@ -1,4 +1,4 @@
-# `Arrays\SortAssociativeArrayByKeyRector`
+# `Expressions\Arrays\SortAssociativeArrayByKeyRector`
 
 Sorts associative arrays by key.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -28,6 +28,12 @@ parameters:
 			message: '#^Parameter \#1 \$configuration of method Ergebnis\\Rector\\Rules\\Configuration\\Options\:\:resolveConfigurationFrom\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
+			path: src/Expressions/Arrays/SortAssociativeArrayByKeyRector.php
+
+		-
+			message: '#^Parameter \#1 \$configuration of method Ergebnis\\Rector\\Rules\\Configuration\\Options\:\:resolveConfigurationFrom\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
 			path: src/Expressions/Matches/SortMatchArmsByConditionalRector.php
 
 		-
@@ -62,6 +68,69 @@ parameters:
 
 		-
 			message: '''
+				#^Access to constant on deprecated class Ergebnis\\Rector\\Rules\\Arrays\\SortAssociativeArrayByKeyRector\:
+				use Ergebnis\\Rector\\Rules\\Expressions\\Arrays\\SortAssociativeArrayByKeyRector instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcasecmp/config.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Ergebnis\\Rector\\Rules\\Arrays\\SortAssociativeArrayByKeyRector\:
+				use Ergebnis\\Rector\\Rules\\Expressions\\Arrays\\SortAssociativeArrayByKeyRector instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcmp/config.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Ergebnis\\Rector\\Rules\\Arrays\\SortAssociativeArrayByKeyRector\:
+				use Ergebnis\\Rector\\Rules\\Expressions\\Arrays\\SortAssociativeArrayByKeyRector instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/config.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Ergebnis\\Rector\\Rules\\Arrays\\SortAssociativeArrayByKeyRector\:
+				use Ergebnis\\Rector\\Rules\\Expressions\\Arrays\\SortAssociativeArrayByKeyRector instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp/config.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Ergebnis\\Rector\\Rules\\Arrays\\SortAssociativeArrayByKeyRector\:
+				use Ergebnis\\Rector\\Rules\\Expressions\\Arrays\\SortAssociativeArrayByKeyRector instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/config.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Ergebnis\\Rector\\Rules\\Arrays\\SortAssociativeArrayByKeyRector\:
+				use Ergebnis\\Rector\\Rules\\Expressions\\Arrays\\SortAssociativeArrayByKeyRector instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithDirectionAsc/config.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Ergebnis\\Rector\\Rules\\Arrays\\SortAssociativeArrayByKeyRector\:
+				use Ergebnis\\Rector\\Rules\\Expressions\\Arrays\\SortAssociativeArrayByKeyRector instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: test/Fixture/Arrays/SortAssociativeArrayByKeyRector/WithDirectionDesc/config.php
+
+		-
+			message: '''
 				#^Access to constant on deprecated class Ergebnis\\Rector\\Rules\\Files\\UseImportRelativeToNamespacePrefixRector\:
 				use ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector instead$#
 			'''
@@ -77,6 +146,24 @@ parameters:
 			identifier: classConstant.deprecatedClass
 			count: 1
 			path: test/Fixture/Files/UseImportRelativeToNamespacePrefixRector/WithSingleNamespacePrefix/config.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Ergebnis\\Rector\\Rules\\Arrays\\SortAssociativeArrayByKeyRector\:
+				use Ergebnis\\Rector\\Rules\\Expressions\\Arrays\\SortAssociativeArrayByKeyRector instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 7
+			path: test/Unit/Arrays/SortAssociativeArrayByKeyRectorConfigureTest.php
+
+		-
+			message: '''
+				#^Call to method configure\(\) of deprecated class Ergebnis\\Rector\\Rules\\Arrays\\SortAssociativeArrayByKeyRector\:
+				use Ergebnis\\Rector\\Rules\\Expressions\\Arrays\\SortAssociativeArrayByKeyRector instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 7
+			path: test/Unit/Arrays/SortAssociativeArrayByKeyRectorConfigureTest.php
 
 		-
 			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Arrays\\SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcasecmpTest\:\:provideFilePathsPhp74\(\) return type has no value type specified in iterable type iterable\.$#'
@@ -143,6 +230,66 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: test/Unit/Configuration/ConfigurationTest.php
+
+		-
+			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Expressions\\Arrays\\SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcasecmpTest\:\:provideFilePathsPhp74\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcasecmpTest.php
+
+		-
+			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Expressions\\Arrays\\SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcasecmpTest\:\:provideFilePathsPhp80\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcasecmpTest.php
+
+		-
+			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Expressions\\Arrays\\SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcmpTest\:\:provideData\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcmpTest.php
+
+		-
+			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Expressions\\Arrays\\SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTest\:\:provideFilePathsPhp74\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTest.php
+
+		-
+			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Expressions\\Arrays\\SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTest\:\:provideFilePathsPhp80\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTest.php
+
+		-
+			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Expressions\\Arrays\\SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcmpTest\:\:provideData\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcmpTest.php
+
+		-
+			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Expressions\\Arrays\\SortAssociativeArrayByKeyRectorWithDefaultConfigurationTest\:\:provideFilePathsPhp74\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithDefaultConfigurationTest.php
+
+		-
+			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Expressions\\Arrays\\SortAssociativeArrayByKeyRectorWithDefaultConfigurationTest\:\:provideFilePathsPhp80\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithDefaultConfigurationTest.php
+
+		-
+			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Expressions\\Arrays\\SortAssociativeArrayByKeyRectorWithDirectionAscTest\:\:provideData\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithDirectionAscTest.php
+
+		-
+			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Expressions\\Arrays\\SortAssociativeArrayByKeyRectorWithDirectionDescTest\:\:provideData\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithDirectionDescTest.php
 
 		-
 			message: '#^Method Ergebnis\\Rector\\Rules\\Test\\Unit\\Expressions\\Matches\\SortMatchArmsByConditionalRectorWithComparisonFunctionStrcasecmpTest\:\:provideData\(\) return type has no value type specified in iterable type iterable\.$#'

--- a/rector.php
+++ b/rector.php
@@ -30,7 +30,7 @@ return static function (Config\RectorConfig $rectorConfig): void {
     $rectorConfig->phpVersion(ValueObject\PhpVersion::PHP_74);
 
     $rectorConfig->rules([
-        Rules\Arrays\SortAssociativeArrayByKeyRector::class,
+        Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class,
         Rules\Expressions\Matches\SortMatchArmsByConditionalRector::class,
         Rules\Faker\GeneratorPropertyFetchToMethodCallRector::class,
     ]);

--- a/src/Expressions/Arrays/ArrayItemWithKey.php
+++ b/src/Expressions/Arrays/ArrayItemWithKey.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Ergebnis\Rector\Rules\Arrays;
+namespace Ergebnis\Rector\Rules\Expressions\Arrays;
 
 use PhpParser\Node;
 

--- a/src/Expressions/Arrays/Key.php
+++ b/src/Expressions/Arrays/Key.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Ergebnis\Rector\Rules\Arrays;
+namespace Ergebnis\Rector\Rules\Expressions\Arrays;
 
 /**
  * @internal

--- a/src/Expressions/Arrays/SortAssociativeArrayByKeyRector.php
+++ b/src/Expressions/Arrays/SortAssociativeArrayByKeyRector.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Ergebnis\Rector\Rules\Arrays;
+namespace Ergebnis\Rector\Rules\Expressions\Arrays;
 
 use Ergebnis\Rector\Rules;
 use PhpParser\Node;
@@ -19,9 +19,6 @@ use Rector\Contract;
 use Rector\Rector;
 use Symplify\RuleDocGenerator;
 
-/**
- * @deprecated use Ergebnis\Rector\Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector instead
- */
 final class SortAssociativeArrayByKeyRector extends Rector\AbstractRector implements
     Contract\Rector\ConfigurableRectorInterface,
     Rules\Configuration\HasConfigurationOptions
@@ -244,15 +241,6 @@ CODE_SAMPLE,
 
     public function refactor(Node $node): ?Node
     {
-        @\trigger_error(
-            \sprintf(
-                '%s is deprecated, use %s instead.',
-                self::class,
-                Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class,
-            ),
-            \E_USER_DEPRECATED,
-        );
-
         if (!$node instanceof Node\Expr\Array_) {
             return null;
         }

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcasecmp/Php74/file.php.inc
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcasecmp/Php74/file.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+    ],
+];
+
+?>
+-----
+<?php
+
+$data = [
+    'bar' => [
+        'quux' => 'quuz',
+        'Quux' => 'quuz',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+    ],
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+];
+
+?>

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcasecmp/Php80/file.php.inc
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcasecmp/Php80/file.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+    ],
+];
+
+?>
+-----
+<?php
+
+$data = [
+    'bar' => [
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+    ],
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+];
+
+?>

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcasecmp/config.php
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcasecmp/config.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/rector-rules
+ */
+
+use Ergebnis\Rector\Rules;
+use Rector\Config;
+
+return static function (Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class, [
+        'comparison_function' => 'strcasecmp',
+    ]);
+};

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcmp/config.php
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcmp/config.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/rector-rules
+ */
+
+use Ergebnis\Rector\Rules;
+use Rector\Config;
+
+return static function (Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class, [
+        'comparison_function' => 'strcmp',
+    ]);
+};

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcmp/file.php.inc
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcmp/file.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+    ],
+];
+
+?>
+-----
+<?php
+
+$data = [
+    'bar' => [
+        'QuZ' => 'qux',
+        'Quux' => 'quuz',
+        'Quz' => 'qux',
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'quux' => 'quuz',
+        'quz' => 'qux',
+    ],
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+];
+
+?>

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php74/file.php.inc
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php74/file.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+    ],
+];
+
+?>
+-----
+<?php
+
+$data = [
+    'bar' => [
+        'quux' => 'quuz',
+        'Quux' => 'quuz',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quz2' => 'qux',
+        'Quz10' => 'qux',
+    ],
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+];
+
+?>

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php80/file.php.inc
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php80/file.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+    ],
+];
+
+?>
+-----
+<?php
+
+$data = [
+    'bar' => [
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quz2' => 'qux',
+        'Quz10' => 'qux',
+    ],
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+];
+
+?>

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/config.php
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/config.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/rector-rules
+ */
+
+use Ergebnis\Rector\Rules;
+use Rector\Config;
+
+return static function (Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class, [
+        'comparison_function' => 'strnatcasecmp',
+    ]);
+};

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp/config.php
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp/config.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/rector-rules
+ */
+
+use Ergebnis\Rector\Rules;
+use Rector\Config;
+
+return static function (Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class, [
+        'comparison_function' => 'strnatcmp',
+    ]);
+};

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp/file.php.inc
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp/file.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+    ],
+];
+
+?>
+-----
+<?php
+
+$data = [
+    'bar' => [
+        'QuZ' => 'qux',
+        'Quux' => 'quuz',
+        'Quz' => 'qux',
+        'Quz2' => 'qux',
+        'Quz10' => 'qux',
+        'quux' => 'quuz',
+        'quz' => 'qux',
+    ],
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+];
+
+?>

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php74/file.php.inc
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php74/file.php.inc
@@ -1,0 +1,143 @@
+<?php
+
+use Namespaced\Bicycle;
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+    ],
+];
+
+$rules = [
+    'ErickSkrauch/line_break_after_statements' => true,
+    'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+    'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+        'ignore_expressions' => true,
+    ],
+    'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+    'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
+    'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
+    'PhpCsFixerCustomFixers/typed_class_constant' => true,
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+        'operators' => [],
+    ],
+    'blank_line_between_import_groups' => false,
+    'blank_lines_before_namespace' => [
+        'max_line_breaks' => 2,
+        'min_line_breaks' => 2,
+    ],
+];
+
+$classNames = [
+    Zebra::class => 'zebra',
+    Apple::class => 'apple',
+    Mango::class => 'mango',
+];
+
+$fullyQualifiedClassNames = [
+    \Zebra::class => 'zebra',
+    \Apple::class => 'apple',
+    \Mango::class => 'mango',
+];
+
+$namespacedClassNames = [
+    Namespaced\Zebra::class => 'zebra',
+    Namespaced\Apple::class => 'apple',
+    Namespaced\Mango::class => 'mango',
+    Namespaced\Bicycle::class => 'biycle',
+];
+
+$mixed = [
+    Namespaced\Zebra::class => 'zebra',
+    'apple' => 'apple',
+    Namespaced\Mango::class => 'mango',
+    'banana' => 'banana',
+    Namespaced\Apple::class => 'apple',
+    Bicycle::class => 'bicycle',
+];
+
+?>
+-----
+<?php
+
+use Namespaced\Bicycle;
+
+$data = [
+    'bar' => [
+        'QuZ' => 'qux',
+        'Quux' => 'quuz',
+        'Quz' => 'qux',
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'quux' => 'quuz',
+        'quz' => 'qux',
+    ],
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+];
+
+$rules = [
+    'ErickSkrauch/line_break_after_statements' => true,
+    'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+    'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+        'ignore_expressions' => true,
+    ],
+    'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+    'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
+    'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
+    'PhpCsFixerCustomFixers/typed_class_constant' => true,
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+        'operators' => [],
+    ],
+    'blank_line_between_import_groups' => false,
+    'blank_lines_before_namespace' => [
+        'max_line_breaks' => 2,
+        'min_line_breaks' => 2,
+    ],
+];
+
+$classNames = [
+    Apple::class => 'apple',
+    Mango::class => 'mango',
+    Zebra::class => 'zebra',
+];
+
+$fullyQualifiedClassNames = [
+    \Apple::class => 'apple',
+    \Mango::class => 'mango',
+    \Zebra::class => 'zebra',
+];
+
+$namespacedClassNames = [
+    Namespaced\Apple::class => 'apple',
+    Namespaced\Bicycle::class => 'biycle',
+    Namespaced\Mango::class => 'mango',
+    Namespaced\Zebra::class => 'zebra',
+];
+
+$mixed = [
+    Bicycle::class => 'bicycle',
+    Namespaced\Apple::class => 'apple',
+    Namespaced\Mango::class => 'mango',
+    Namespaced\Zebra::class => 'zebra',
+    'apple' => 'apple',
+    'banana' => 'banana',
+];
+
+?>

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php80/file.php.inc
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php80/file.php.inc
@@ -1,0 +1,143 @@
+<?php
+
+use Namespaced\Bicycle;
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+    ],
+];
+
+$rules = [
+    'ErickSkrauch/line_break_after_statements' => true,
+    'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+    'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+        'ignore_expressions' => true,
+    ],
+    'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+    'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
+    'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
+    'PhpCsFixerCustomFixers/typed_class_constant' => true,
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+        'operators' => [],
+    ],
+    'blank_line_between_import_groups' => false,
+    'blank_lines_before_namespace' => [
+        'max_line_breaks' => 2,
+        'min_line_breaks' => 2,
+    ],
+];
+
+$classNames = [
+    Zebra::class => 'zebra',
+    Apple::class => 'apple',
+    Mango::class => 'mango',
+];
+
+$fullyQualifiedClassNames = [
+    \Zebra::class => 'zebra',
+    \Apple::class => 'apple',
+    \Mango::class => 'mango',
+];
+
+$namespacedClassNames = [
+    Namespaced\Zebra::class => 'zebra',
+    Namespaced\Apple::class => 'apple',
+    Namespaced\Mango::class => 'mango',
+    Namespaced\Bicycle::class => 'biycle',
+];
+
+$mixed = [
+    Namespaced\Zebra::class => 'zebra',
+    'apple' => 'apple',
+    Namespaced\Mango::class => 'mango',
+    'banana' => 'banana',
+    Namespaced\Apple::class => 'apple',
+    Bicycle::class => 'bicycle',
+];
+
+?>
+-----
+<?php
+
+use Namespaced\Bicycle;
+
+$data = [
+    'bar' => [
+        'QuZ' => 'qux',
+        'Quux' => 'quuz',
+        'Quz' => 'qux',
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'quux' => 'quuz',
+        'quz' => 'qux',
+    ],
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+];
+
+$rules = [
+    'ErickSkrauch/line_break_after_statements' => true,
+    'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+    'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+        'ignore_expressions' => true,
+    ],
+    'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+    'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
+    'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
+    'PhpCsFixerCustomFixers/typed_class_constant' => true,
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+        'operators' => [],
+    ],
+    'blank_line_between_import_groups' => false,
+    'blank_lines_before_namespace' => [
+        'max_line_breaks' => 2,
+        'min_line_breaks' => 2,
+    ],
+];
+
+$classNames = [
+    Apple::class => 'apple',
+    Mango::class => 'mango',
+    Zebra::class => 'zebra',
+];
+
+$fullyQualifiedClassNames = [
+    \Apple::class => 'apple',
+    \Mango::class => 'mango',
+    \Zebra::class => 'zebra',
+];
+
+$namespacedClassNames = [
+    Namespaced\Apple::class => 'apple',
+    Namespaced\Bicycle::class => 'biycle',
+    Namespaced\Mango::class => 'mango',
+    Namespaced\Zebra::class => 'zebra',
+];
+
+$mixed = [
+    Bicycle::class => 'bicycle',
+    Namespaced\Apple::class => 'apple',
+    Namespaced\Mango::class => 'mango',
+    Namespaced\Zebra::class => 'zebra',
+    'apple' => 'apple',
+    'banana' => 'banana',
+];
+
+?>

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/config.php
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/config.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/rector-rules
+ */
+
+use Ergebnis\Rector\Rules;
+use Rector\Config;
+
+return static function (Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class);
+};

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionAsc/config.php
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionAsc/config.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/rector-rules
+ */
+
+use Ergebnis\Rector\Rules;
+use Rector\Config;
+
+return static function (Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class, [
+        'direction' => 'asc',
+    ]);
+};

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionAsc/file.php.inc
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionAsc/file.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+    ],
+];
+
+?>
+-----
+<?php
+
+$data = [
+    'bar' => [
+        'QuZ' => 'qux',
+        'Quux' => 'quuz',
+        'Quz' => 'qux',
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'quux' => 'quuz',
+        'quz' => 'qux',
+    ],
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+];
+
+?>

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionDesc/config.php
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionDesc/config.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/rector-rules
+ */
+
+use Ergebnis\Rector\Rules;
+use Rector\Config;
+
+return static function (Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class, [
+        'direction' => 'desc',
+    ]);
+};

--- a/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionDesc/file.php.inc
+++ b/test/Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionDesc/file.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'Quz10' => 'qux',
+        'Quz2' => 'qux',
+        'Quz' => 'qux',
+        'QuZ' => 'qux',
+        'quz' => 'qux',
+        'Quux' => 'quuz',
+        'quux' => 'quuz',
+    ],
+];
+
+?>
+-----
+<?php
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'quz' => 'qux',
+        'quux' => 'quuz',
+        'Quz2' => 'qux',
+        'Quz10' => 'qux',
+        'Quz' => 'qux',
+        'Quux' => 'quuz',
+        'QuZ' => 'qux',
+    ],
+];
+
+?>

--- a/test/Unit/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcasecmpTest.php
+++ b/test/Unit/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcasecmpTest.php
@@ -18,14 +18,14 @@ use Rector\Testing;
 /**
  * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
  *
- * @uses \Ergebnis\Rector\Rules\Arrays\ArrayItemWithKey
- * @uses \Ergebnis\Rector\Rules\Arrays\Key
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionDescription
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionName
  * @uses \Ergebnis\Rector\Rules\Configuration\Options
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionValue
+ * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\ArrayItemWithKey
+ * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
 final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcasecmpTest extends Testing\PHPUnit\AbstractRectorTestCase
 {

--- a/test/Unit/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcmpTest.php
+++ b/test/Unit/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcmpTest.php
@@ -18,14 +18,14 @@ use Rector\Testing;
 /**
  * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
  *
- * @uses \Ergebnis\Rector\Rules\Arrays\ArrayItemWithKey
- * @uses \Ergebnis\Rector\Rules\Arrays\Key
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionDescription
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionName
  * @uses \Ergebnis\Rector\Rules\Configuration\Options
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionValue
+ * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\ArrayItemWithKey
+ * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
 final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcmpTest extends Testing\PHPUnit\AbstractRectorTestCase
 {

--- a/test/Unit/Arrays/SortAssociativeArrayByKeyRectorWithDefaultConfigurationTest.php
+++ b/test/Unit/Arrays/SortAssociativeArrayByKeyRectorWithDefaultConfigurationTest.php
@@ -18,14 +18,14 @@ use Rector\Testing;
 /**
  * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
  *
- * @uses \Ergebnis\Rector\Rules\Arrays\ArrayItemWithKey
- * @uses \Ergebnis\Rector\Rules\Arrays\Key
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionDescription
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionName
  * @uses \Ergebnis\Rector\Rules\Configuration\Options
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionValue
+ * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\ArrayItemWithKey
+ * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
 final class SortAssociativeArrayByKeyRectorWithDefaultConfigurationTest extends Testing\PHPUnit\AbstractRectorTestCase
 {

--- a/test/Unit/Arrays/SortAssociativeArrayByKeyRectorWithDirectionAscTest.php
+++ b/test/Unit/Arrays/SortAssociativeArrayByKeyRectorWithDirectionAscTest.php
@@ -18,14 +18,14 @@ use Rector\Testing;
 /**
  * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
  *
- * @uses \Ergebnis\Rector\Rules\Arrays\ArrayItemWithKey
- * @uses \Ergebnis\Rector\Rules\Arrays\Key
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionDescription
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionName
  * @uses \Ergebnis\Rector\Rules\Configuration\Options
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionValue
+ * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\ArrayItemWithKey
+ * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
 final class SortAssociativeArrayByKeyRectorWithDirectionAscTest extends Testing\PHPUnit\AbstractRectorTestCase
 {

--- a/test/Unit/Arrays/SortAssociativeArrayByKeyRectorWithDirectionDescTest.php
+++ b/test/Unit/Arrays/SortAssociativeArrayByKeyRectorWithDirectionDescTest.php
@@ -18,14 +18,14 @@ use Rector\Testing;
 /**
  * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
  *
- * @uses \Ergebnis\Rector\Rules\Arrays\ArrayItemWithKey
- * @uses \Ergebnis\Rector\Rules\Arrays\Key
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionDescription
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionName
  * @uses \Ergebnis\Rector\Rules\Configuration\Options
  * @uses \Ergebnis\Rector\Rules\Configuration\OptionValue
+ * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\ArrayItemWithKey
+ * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
 final class SortAssociativeArrayByKeyRectorWithDirectionDescTest extends Testing\PHPUnit\AbstractRectorTestCase
 {

--- a/test/Unit/Expressions/Arrays/ArrayItemWithKeyTest.php
+++ b/test/Unit/Expressions/Arrays/ArrayItemWithKeyTest.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Arrays;
+namespace Ergebnis\Rector\Rules\Test\Unit\Expressions\Arrays;
 
 use Ergebnis\Rector\Rules;
 use PhpParser\Node;
 use PHPUnit\Framework;
 
 /**
- * @covers \Ergebnis\Rector\Rules\Arrays\ArrayItemWithKey
+ * @covers \Ergebnis\Rector\Rules\Expressions\Arrays\ArrayItemWithKey
  *
- * @uses \Ergebnis\Rector\Rules\Arrays\Key
+ * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
 final class ArrayItemWithKeyTest extends Framework\TestCase
 {
@@ -31,9 +31,9 @@ final class ArrayItemWithKeyTest extends Framework\TestCase
             new Node\Scalar\String_('bar'),
         );
 
-        $key = Rules\Arrays\Key::fromString('baz');
+        $key = Rules\Expressions\Arrays\Key::fromString('baz');
 
-        $arrayItemWithKey = Rules\Arrays\ArrayItemWithKey::create(
+        $arrayItemWithKey = Rules\Expressions\Arrays\ArrayItemWithKey::create(
             $arrayItem,
             $key,
         );

--- a/test/Unit/Expressions/Arrays/KeyTest.php
+++ b/test/Unit/Expressions/Arrays/KeyTest.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Ergebnis\Rector\Rules\Test\Unit\Arrays;
+namespace Ergebnis\Rector\Rules\Test\Unit\Expressions\Arrays;
 
 use Ergebnis\DataProvider;
 use Ergebnis\Rector\Rules;
 use PHPUnit\Framework;
 
 /**
- * @covers \Ergebnis\Rector\Rules\Arrays\Key
+ * @covers \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
 final class KeyTest extends Framework\TestCase
 {
@@ -27,7 +27,7 @@ final class KeyTest extends Framework\TestCase
      */
     public function testFromStringReturnsKey(string $value): void
     {
-        $key = Rules\Arrays\Key::fromString($value);
+        $key = Rules\Expressions\Arrays\Key::fromString($value);
 
         self::assertSame($value, $key->toString());
     }

--- a/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorConfigureTest.php
+++ b/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorConfigureTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/rector-rules
+ */
+
+namespace Ergebnis\Rector\Rules\Test\Unit\Expressions\Arrays;
+
+use Ergebnis\Rector\Rules;
+use Rector\Testing;
+
+/**
+ * @covers \Ergebnis\Rector\Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector
+ *
+ * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
+ * @uses \Ergebnis\Rector\Rules\Configuration\InvalidOptionValue
+ * @uses \Ergebnis\Rector\Rules\Configuration\Option
+ * @uses \Ergebnis\Rector\Rules\Configuration\OptionDescription
+ * @uses \Ergebnis\Rector\Rules\Configuration\OptionName
+ * @uses \Ergebnis\Rector\Rules\Configuration\Options
+ * @uses \Ergebnis\Rector\Rules\Configuration\OptionValue
+ * @uses \Ergebnis\Rector\Rules\Configuration\UnknownOptionName
+ */
+final class SortAssociativeArrayByKeyRectorConfigureTest extends Testing\PHPUnit\AbstractLazyTestCase
+{
+    public function testConfigureRejectsUnknownKeys(): void
+    {
+        $rector = $this->make(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class);
+
+        $this->expectException(Rules\Configuration\UnknownOptionName::class);
+
+        $rector->configure([
+            'foo' => 'bar',
+        ]);
+    }
+
+    public function testConfigureRejectsNonStringComparisonFunction(): void
+    {
+        $rector = $this->make(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class);
+
+        $this->expectException(Rules\Configuration\InvalidOptionValue::class);
+
+        $rector->configure([
+            'comparison_function' => 123,
+        ]);
+    }
+
+    public function testConfigureRejectsInvalidComparisonFunction(): void
+    {
+        $rector = $this->make(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class);
+
+        $this->expectException(Rules\Configuration\InvalidOptionValue::class);
+
+        $rector->configure([
+            'comparison_function' => 'invalid',
+        ]);
+    }
+
+    public function testConfigureRejectsNonStringDirection(): void
+    {
+        $rector = $this->make(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class);
+
+        $this->expectException(Rules\Configuration\InvalidOptionValue::class);
+
+        $rector->configure([
+            'direction' => 123,
+        ]);
+    }
+
+    public function testConfigureRejectsInvalidDirection(): void
+    {
+        $rector = $this->make(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class);
+
+        $this->expectException(Rules\Configuration\InvalidOptionValue::class);
+
+        $rector->configure([
+            'direction' => 'invalid',
+        ]);
+    }
+
+    public function testConfigureAcceptsValidConfiguration(): void
+    {
+        $rector = $this->make(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class);
+
+        $rector->configure([
+            'comparison_function' => 'strnatcasecmp',
+            'direction' => 'desc',
+        ]);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testConfigureAcceptsEmptyConfiguration(): void
+    {
+        $rector = $this->make(Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class);
+
+        $rector->configure([]);
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcasecmpTest.php
+++ b/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcasecmpTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Ergebnis\Rector\Rules\Test\Unit\Arrays;
+namespace Ergebnis\Rector\Rules\Test\Unit\Expressions\Arrays;
 
 use Rector\Testing;
 
 /**
- * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
+ * @covers \Ergebnis\Rector\Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector
  *
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
@@ -27,7 +27,7 @@ use Rector\Testing;
  * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\ArrayItemWithKey
  * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
-final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTest extends Testing\PHPUnit\AbstractRectorTestCase
+final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcasecmpTest extends Testing\PHPUnit\AbstractRectorTestCase
 {
     /**
      * @dataProvider provideFilePathsPhp74
@@ -43,7 +43,7 @@ final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTe
 
     public static function provideFilePathsPhp74(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php74');
+        return self::yieldFilesFromDirectory(__DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcasecmp/Php74');
     }
 
     /**
@@ -60,11 +60,11 @@ final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTe
 
     public static function provideFilePathsPhp80(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php80');
+        return self::yieldFilesFromDirectory(__DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcasecmp/Php80');
     }
 
     public function provideConfigFilePath(): string
     {
-        return __DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/config.php';
+        return __DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcasecmp/config.php';
     }
 }

--- a/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcmpTest.php
+++ b/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcmpTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Ergebnis\Rector\Rules\Test\Unit\Arrays;
+namespace Ergebnis\Rector\Rules\Test\Unit\Expressions\Arrays;
 
 use Rector\Testing;
 
 /**
- * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
+ * @covers \Ergebnis\Rector\Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector
  *
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
@@ -27,7 +27,7 @@ use Rector\Testing;
  * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\ArrayItemWithKey
  * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
-final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcmpTest extends Testing\PHPUnit\AbstractRectorTestCase
+final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrcmpTest extends Testing\PHPUnit\AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData
@@ -39,11 +39,11 @@ final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcmpTest e
 
     public static function provideData(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp');
+        return self::yieldFilesFromDirectory(__DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcmp');
     }
 
     public function provideConfigFilePath(): string
     {
-        return __DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp/config.php';
+        return __DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrcmp/config.php';
     }
 }

--- a/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTest.php
+++ b/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Ergebnis\Rector\Rules\Test\Unit\Arrays;
+namespace Ergebnis\Rector\Rules\Test\Unit\Expressions\Arrays;
 
 use Rector\Testing;
 
 /**
- * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
+ * @covers \Ergebnis\Rector\Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector
  *
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
@@ -43,7 +43,7 @@ final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTe
 
     public static function provideFilePathsPhp74(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php74');
+        return self::yieldFilesFromDirectory(__DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php74');
     }
 
     /**
@@ -60,11 +60,11 @@ final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTe
 
     public static function provideFilePathsPhp80(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php80');
+        return self::yieldFilesFromDirectory(__DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php80');
     }
 
     public function provideConfigFilePath(): string
     {
-        return __DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/config.php';
+        return __DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/config.php';
     }
 }

--- a/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcmpTest.php
+++ b/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcmpTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Ergebnis\Rector\Rules\Test\Unit\Arrays;
+namespace Ergebnis\Rector\Rules\Test\Unit\Expressions\Arrays;
 
 use Rector\Testing;
 
 /**
- * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
+ * @covers \Ergebnis\Rector\Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector
  *
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
@@ -39,11 +39,11 @@ final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcmpTest e
 
     public static function provideData(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp');
+        return self::yieldFilesFromDirectory(__DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp');
     }
 
     public function provideConfigFilePath(): string
     {
-        return __DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp/config.php';
+        return __DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp/config.php';
     }
 }

--- a/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithDefaultConfigurationTest.php
+++ b/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithDefaultConfigurationTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Ergebnis\Rector\Rules\Test\Unit\Arrays;
+namespace Ergebnis\Rector\Rules\Test\Unit\Expressions\Arrays;
 
 use Rector\Testing;
 
 /**
- * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
+ * @covers \Ergebnis\Rector\Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector
  *
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
@@ -27,7 +27,7 @@ use Rector\Testing;
  * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\ArrayItemWithKey
  * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
-final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTest extends Testing\PHPUnit\AbstractRectorTestCase
+final class SortAssociativeArrayByKeyRectorWithDefaultConfigurationTest extends Testing\PHPUnit\AbstractRectorTestCase
 {
     /**
      * @dataProvider provideFilePathsPhp74
@@ -43,7 +43,7 @@ final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTe
 
     public static function provideFilePathsPhp74(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php74');
+        return self::yieldFilesFromDirectory(__DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php74');
     }
 
     /**
@@ -60,11 +60,11 @@ final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcasecmpTe
 
     public static function provideFilePathsPhp80(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/Php80');
+        return self::yieldFilesFromDirectory(__DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/Php80');
     }
 
     public function provideConfigFilePath(): string
     {
-        return __DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcasecmp/config.php';
+        return __DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDefaultConfiguration/config.php';
     }
 }

--- a/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithDirectionAscTest.php
+++ b/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithDirectionAscTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Ergebnis\Rector\Rules\Test\Unit\Arrays;
+namespace Ergebnis\Rector\Rules\Test\Unit\Expressions\Arrays;
 
 use Rector\Testing;
 
 /**
- * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
+ * @covers \Ergebnis\Rector\Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector
  *
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
@@ -27,7 +27,7 @@ use Rector\Testing;
  * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\ArrayItemWithKey
  * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
-final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcmpTest extends Testing\PHPUnit\AbstractRectorTestCase
+final class SortAssociativeArrayByKeyRectorWithDirectionAscTest extends Testing\PHPUnit\AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData
@@ -39,11 +39,11 @@ final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcmpTest e
 
     public static function provideData(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp');
+        return self::yieldFilesFromDirectory(__DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionAsc');
     }
 
     public function provideConfigFilePath(): string
     {
-        return __DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp/config.php';
+        return __DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionAsc/config.php';
     }
 }

--- a/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithDirectionDescTest.php
+++ b/test/Unit/Expressions/Arrays/SortAssociativeArrayByKeyRectorWithDirectionDescTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/rector-rules
  */
 
-namespace Ergebnis\Rector\Rules\Test\Unit\Arrays;
+namespace Ergebnis\Rector\Rules\Test\Unit\Expressions\Arrays;
 
 use Rector\Testing;
 
 /**
- * @covers \Ergebnis\Rector\Rules\Arrays\SortAssociativeArrayByKeyRector
+ * @covers \Ergebnis\Rector\Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector
  *
  * @uses \Ergebnis\Rector\Rules\Configuration\Configuration
  * @uses \Ergebnis\Rector\Rules\Configuration\Option
@@ -27,7 +27,7 @@ use Rector\Testing;
  * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\ArrayItemWithKey
  * @uses \Ergebnis\Rector\Rules\Expressions\Arrays\Key
  */
-final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcmpTest extends Testing\PHPUnit\AbstractRectorTestCase
+final class SortAssociativeArrayByKeyRectorWithDirectionDescTest extends Testing\PHPUnit\AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData
@@ -39,11 +39,11 @@ final class SortAssociativeArrayByKeyRectorWithComparisonFunctionStrnatcmpTest e
 
     public static function provideData(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp');
+        return self::yieldFilesFromDirectory(__DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionDesc');
     }
 
     public function provideConfigFilePath(): string
     {
-        return __DIR__ . '/../../Fixture/Arrays/SortAssociativeArrayByKeyRector/WithComparisonFunctionStrnatcmp/config.php';
+        return __DIR__ . '/../../../Fixture/Expressions/Arrays/SortAssociativeArrayByKeyRector/WithDirectionDesc/config.php';
     }
 }


### PR DESCRIPTION
This pull request

- [x] deprecates `Arrays\SortAssociativeArrayByKeyRector` in favor of `Expressions\Arrays\SortAssociativeArrayByKeyRector`