### PR TITLE
Fix: Adjust `RemoveNamedArgumentForSingleParameterRector` to ignore first-class callables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.18.0...main`][1.18.0...main].
 
+### Fixed
+
+- Adjusted `Rules\Expressions\CallLikes\RemoveNamedArgumentForSingleParameterRector` to ignore first-class callables ([#339]), by [@localheinz]
+
 ## [`1.18.0`][1.18.0]
 
 For a full diff see [`1.17.0...1.18.0`][1.17.0...1.18.0].
@@ -460,5 +464,6 @@ For a full diff see [`fd198f0...0.1.0`][fd198f0...0.1.0].
 [#335]: https://github.com/ergebnis/rector-rules/pull/335
 [#336]: https://github.com/ergebnis/rector-rules/pull/336
 [#337]: https://github.com/ergebnis/rector-rules/pull/337
+[#339]: https://github.com/ergebnis/rector-rules/pull/339
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Expressions/CallLikes/RemoveNamedArgumentForSingleParameterRector.php
+++ b/src/Expressions/CallLikes/RemoveNamedArgumentForSingleParameterRector.php
@@ -60,6 +60,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $namedArguments = \array_filter($node->getArgs(), static function ($argument): bool {
             return $argument->name instanceof Node\Identifier;
         });

--- a/test/Fixture/Expressions/CallLikes/RemoveNamedArgumentForSingleParameterRector/first-class-callable.php.inc
+++ b/test/Fixture/Expressions/CallLikes/RemoveNamedArgumentForSingleParameterRector/first-class-callable.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ergebnis\Rector\Rules\Test\Fixture\Expressions\CallLikes\RemoveNamedArgumentForSingleParameterRector;
+
+$callable = strlen(...);
+
+?>


### PR DESCRIPTION
This pull request

- [x] adjusts `RemoveNamedArgumentForSingleParameterRector` to ignore first-class callables