### PR TITLE
Fix: Return `null` when node was not modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.18.1...main`][1.18.1...main].
 
+### Fixed
+
+- Adjusted `Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector` and `Rules\Expressions\Matches\SortMatchArmsByConditionalRector` to return `null` when they do not modify a node to avoid cache invalidation ([#355]), by [@localheinz]
+
 ## [`1.18.1`][1.18.1]
 
 For a full diff see [`1.18.0...1.18.1`][1.18.0...1.18.1].
@@ -471,5 +475,6 @@ For a full diff see [`fd198f0...0.1.0`][fd198f0...0.1.0].
 [#336]: https://github.com/ergebnis/rector-rules/pull/336
 [#337]: https://github.com/ergebnis/rector-rules/pull/337
 [#339]: https://github.com/ergebnis/rector-rules/pull/339
+[#355]: https://github.com/ergebnis/rector-rules/pull/355
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Arrays/SortAssociativeArrayByKeyRector.php
+++ b/src/Arrays/SortAssociativeArrayByKeyRector.php
@@ -287,9 +287,15 @@ CODE_SAMPLE,
             );
         });
 
-        $node->items = \array_map(static function (Rules\Expressions\Arrays\ArrayItemWithKey $arrayItemWithKey): Node\Expr\ArrayItem {
+        $sortedItems = \array_map(static function (Rules\Expressions\Arrays\ArrayItemWithKey $arrayItemWithKey): Node\Expr\ArrayItem {
             return $arrayItemWithKey->arrayItem();
         }, $arrayItemsWithKeys);
+
+        if ($sortedItems === $node->items) {
+            return null;
+        }
+
+        $node->items = $sortedItems;
 
         return $node;
     }

--- a/src/Expressions/Arrays/SortAssociativeArrayByKeyRector.php
+++ b/src/Expressions/Arrays/SortAssociativeArrayByKeyRector.php
@@ -275,9 +275,15 @@ CODE_SAMPLE,
             );
         });
 
-        $node->items = \array_map(static function (Rules\Expressions\Arrays\ArrayItemWithKey $arrayItemWithKey): Node\Expr\ArrayItem {
+        $sortedItems = \array_map(static function (Rules\Expressions\Arrays\ArrayItemWithKey $arrayItemWithKey): Node\Expr\ArrayItem {
             return $arrayItemWithKey->arrayItem();
         }, $arrayItemsWithKeys);
+
+        if ($sortedItems === $node->items) {
+            return null;
+        }
+
+        $node->items = $sortedItems;
 
         return $node;
     }

--- a/src/Expressions/Matches/SortMatchArmsByConditionalRector.php
+++ b/src/Expressions/Matches/SortMatchArmsByConditionalRector.php
@@ -353,6 +353,10 @@ CODE_SAMPLE,
             $sortedArms[] = $defaultArm;
         }
 
+        if ($sortedArms === $node->arms) {
+            return null;
+        }
+
         $node->arms = $sortedArms;
 
         return $node;


### PR DESCRIPTION
This pull request

- [x] returns `null` from `Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector` and `Rules\Expressions\Matches\SortMatchArmsByConditionalRector` when a node was not modified to avoid cache invalidation