### PR TITLE
Fix: Reference namespaced symbols in doc blocks consistently with code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.18.2...main`][1.18.2...main].
 
+### Fixed
+
+- Adjusted `Rules\Files\ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector` to reference namespaced symbols in doc blocks consistently with code ([#361]), by [@localheinz]
+
 ## [`1.18.2`][1.18.2]
 
 For a full diff see [`1.18.1...1.18.2`][1.18.1...1.18.2].
@@ -482,5 +486,6 @@ For a full diff see [`fd198f0...0.1.0`][fd198f0...0.1.0].
 [#337]: https://github.com/ergebnis/rector-rules/pull/337
 [#339]: https://github.com/ergebnis/rector-rules/pull/339
 [#355]: https://github.com/ergebnis/rector-rules/pull/355
+[#361]: https://github.com/ergebnis/rector-rules/pull/361
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Configuration/Options.php
+++ b/src/Configuration/Options.php
@@ -26,7 +26,7 @@ final class Options
     private array $values;
 
     /**
-     * @param array<string, Option> $values
+     * @param array<string, Rules\Configuration\Option> $values
      */
     private function __construct(array $values)
     {

--- a/src/Expressions/Matches/SortMatchArmsByConditionalRector.php
+++ b/src/Expressions/Matches/SortMatchArmsByConditionalRector.php
@@ -37,12 +37,12 @@ final class SortMatchArmsByConditionalRector extends Rector\AbstractRector imple
     private const CONFIGURATION_KEY_DIRECTION = 'direction';
 
     /**
-     * @var \Closure(IntConditional, IntConditional): int
+     * @var \Closure(Rules\Expressions\Matches\IntConditional, Rules\Expressions\Matches\IntConditional):int
      */
     private \Closure $intConditionalComparator;
 
     /**
-     * @var \Closure(StringConditional, StringConditional): int
+     * @var \Closure(Rules\Expressions\Matches\StringConditional, Rules\Expressions\Matches\StringConditional):int
      */
     private \Closure $stringConditionalComparator;
     private int $multiplier;
@@ -297,7 +297,7 @@ CODE_SAMPLE,
 
         $defaultArm = null;
 
-        /** @var list<MatchArmWithConditional> $matchArmsWithConditionals */
+        /** @var list<Rules\Expressions\Matches\MatchArmWithConditional> $matchArmsWithConditionals */
         $matchArmsWithConditionals = [];
 
         foreach ($node->arms as $arm) {

--- a/src/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector.php
+++ b/src/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector.php
@@ -39,12 +39,12 @@ final class ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector extends Re
     private bool $forceRelativeReferences = false;
 
     /**
-     * @var list<NamespacePrefix>
+     * @var list<Rules\Files\NamespacePrefix>
      */
     private array $namespacePrefixes = [];
 
     /**
-     * @var list<NamespacePrefix>
+     * @var list<Rules\Files\NamespacePrefix>
      */
     private array $parentNamespacePrefixes = [];
 
@@ -525,7 +525,7 @@ CODE_SAMPLE
 
     /**
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
-     * @param list<NamespacePrefix>                        $moreSpecificNamespacePrefixes
+     * @param list<Rules\Files\NamespacePrefix>            $moreSpecificNamespacePrefixes
      * @param array<string, true>                          $classReferences
      */
     private function processNamespacePrefix(
@@ -534,7 +534,7 @@ CODE_SAMPLE
         array $moreSpecificNamespacePrefixes,
         array $classReferences
     ): bool {
-        /** @var array<string, Reference> $aliasesToReferences */
+        /** @var array<string, Rules\Files\Reference> $aliasesToReferences */
         $aliasesToReferences = [];
 
         $hasNamespacePrefixImport = false;
@@ -658,7 +658,7 @@ CODE_SAMPLE
 
     /**
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
-     * @param list<NamespacePrefix>                        $moreSpecificNamespacePrefixes
+     * @param list<Rules\Files\NamespacePrefix>            $moreSpecificNamespacePrefixes
      */
     private static function hasMatchingNamespacePrefixImports(
         Node $containerNode,
@@ -762,7 +762,7 @@ CODE_SAMPLE
 
     /**
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
-     * @param list<NamespacePrefix>                        $moreSpecificNamespacePrefixes
+     * @param list<Rules\Files\NamespacePrefix>            $moreSpecificNamespacePrefixes
      */
     private static function hasSourceWrittenFullyQualifiedReferencesMatchingPrefix(
         Node $containerNode,
@@ -827,7 +827,7 @@ CODE_SAMPLE
 
     /**
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
-     * @param list<NamespacePrefix>                        $moreSpecificNamespacePrefixes
+     * @param list<Rules\Files\NamespacePrefix>            $moreSpecificNamespacePrefixes
      */
     private static function hasPartiallyQualifiedReferencesMatchingNamespacePrefix(
         Node $containerNode,
@@ -927,7 +927,7 @@ CODE_SAMPLE
 
     /**
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
-     * @param list<NamespacePrefix>                        $moreSpecificNamespacePrefixes
+     * @param list<Rules\Files\NamespacePrefix>            $moreSpecificNamespacePrefixes
      */
     private function rewriteNamesInStatements(
         Node $containerNode,
@@ -1013,8 +1013,8 @@ CODE_SAMPLE
 
     /**
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
-     * @param array<string, Reference>                     $aliasesToReferences
-     * @param list<NamespacePrefix>                        $moreSpecificNamespacePrefixes
+     * @param array<string, Rules\Files\Reference>         $aliasesToReferences
+     * @param list<Rules\Files\NamespacePrefix>            $moreSpecificNamespacePrefixes
      * @param array<string, true>                          $classReferences
      */
     private function rewriteNamesInDocBlocks(
@@ -1329,17 +1329,17 @@ CODE_SAMPLE
 
     /**
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
-     * @param list<NamespacePrefix>                        $existingParentNamespacePrefixes
-     * @param list<NamespacePrefix>                        $existingNamespacePrefixes
+     * @param list<Rules\Files\NamespacePrefix>            $existingParentNamespacePrefixes
+     * @param list<Rules\Files\NamespacePrefix>            $existingNamespacePrefixes
      *
-     * @return list<NamespacePrefix>
+     * @return list<Rules\Files\NamespacePrefix>
      */
     private static function discoverParentNamespacePrefixesFromFile(
         Node $containerNode,
         array $existingParentNamespacePrefixes,
         array $existingNamespacePrefixes
     ): array {
-        /** @var array<string, NamespacePrefix> $discovered */
+        /** @var array<string, Rules\Files\NamespacePrefix> $discovered */
         $discovered = [];
 
         $collectFirstSegment = static function (string $reference) use (&$discovered): void {
@@ -1480,10 +1480,10 @@ CODE_SAMPLE
 
     /**
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
-     * @param list<NamespacePrefix>                        $parentNamespacePrefixes
-     * @param list<NamespacePrefix>                        $namespacePrefixes
+     * @param list<Rules\Files\NamespacePrefix>            $parentNamespacePrefixes
+     * @param list<Rules\Files\NamespacePrefix>            $namespacePrefixes
      *
-     * @return list<NamespacePrefix>
+     * @return list<Rules\Files\NamespacePrefix>
      */
     private static function discoverNamespacePrefixesFromParentNamespacePrefixes(
         Node $containerNode,
@@ -1494,7 +1494,7 @@ CODE_SAMPLE
             return [];
         }
 
-        /** @var array<string, NamespacePrefix> $discoveredNamespacePrefixes */
+        /** @var array<string, Rules\Files\NamespacePrefix> $discoveredNamespacePrefixes */
         $discoveredNamespacePrefixes = [];
 
         $existingKeys = [];
@@ -1607,9 +1607,9 @@ CODE_SAMPLE
     }
 
     /**
-     * @param list<NamespacePrefix>          $parentNamespacePrefixes
-     * @param array<string, true>            $existingKeys
-     * @param array<string, NamespacePrefix> $discovered
+     * @param list<Rules\Files\NamespacePrefix>          $parentNamespacePrefixes
+     * @param array<string, true>                        $existingKeys
+     * @param array<string, Rules\Files\NamespacePrefix> $discovered
      */
     private static function discoverChildPrefix(
         string $reference,
@@ -1701,7 +1701,7 @@ CODE_SAMPLE
 
     /**
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
-     * @param list<NamespacePrefix>                        $moreSpecificNamespacePrefixes
+     * @param list<Rules\Files\NamespacePrefix>            $moreSpecificNamespacePrefixes
      */
     private static function removeMatchingImportsAndAddNamespacePrefixImport(
         Node $containerNode,

--- a/src/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector.php
+++ b/src/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector.php
@@ -500,6 +500,8 @@ CODE_SAMPLE
 
         $changed = false;
 
+        $classReferences = self::fullyQualifiedReferences(\array_values($containerNode->stmts));
+
         foreach ($namespacePrefixes as $namespacePrefix) {
             $moreSpecificNamespacePrefixes = [];
 
@@ -509,7 +511,7 @@ CODE_SAMPLE
                 }
             }
 
-            if ($this->processNamespacePrefix($containerNode, $namespacePrefix, $moreSpecificNamespacePrefixes)) {
+            if ($this->processNamespacePrefix($containerNode, $namespacePrefix, $moreSpecificNamespacePrefixes, $classReferences)) {
                 $changed = true;
             }
         }
@@ -524,11 +526,13 @@ CODE_SAMPLE
     /**
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
      * @param list<NamespacePrefix>                        $moreSpecificNamespacePrefixes
+     * @param array<string, true>                          $classReferences
      */
     private function processNamespacePrefix(
         Node $containerNode,
         Rules\Files\NamespacePrefix $namespacePrefix,
-        array $moreSpecificNamespacePrefixes
+        array $moreSpecificNamespacePrefixes,
+        array $classReferences
     ): bool {
         /** @var array<string, Reference> $aliasesToReferences */
         $aliasesToReferences = [];
@@ -630,6 +634,7 @@ CODE_SAMPLE
             $namespacePrefix,
             $moreSpecificNamespacePrefixes,
             $namespacePrefixOfContainingFile,
+            $classReferences,
         );
 
         if (
@@ -1010,17 +1015,19 @@ CODE_SAMPLE
      * @param Node\Stmt\Namespace_|PhpParser\Node\FileNode $containerNode
      * @param array<string, Reference>                     $aliasesToReferences
      * @param list<NamespacePrefix>                        $moreSpecificNamespacePrefixes
+     * @param array<string, true>                          $classReferences
      */
     private function rewriteNamesInDocBlocks(
         Node $containerNode,
         array $aliasesToReferences,
         Rules\Files\NamespacePrefix $namespacePrefix,
         array $moreSpecificNamespacePrefixes,
-        ?Rules\Files\NamespacePrefix $namespacePrefixOfContainingFile
+        ?Rules\Files\NamespacePrefix $namespacePrefixOfContainingFile,
+        array $classReferences
     ): bool {
         $anyDocBlockChanged = false;
 
-        $this->traverseNodesWithCallable($containerNode->stmts, function (Node $node) use (&$anyDocBlockChanged, $aliasesToReferences, $containerNode, $namespacePrefix, $moreSpecificNamespacePrefixes, $namespacePrefixOfContainingFile): ?Node {
+        $this->traverseNodesWithCallable($containerNode->stmts, function (Node $node) use (&$anyDocBlockChanged, $aliasesToReferences, $classReferences, $containerNode, $namespacePrefix, $moreSpecificNamespacePrefixes, $namespacePrefixOfContainingFile): ?Node {
             if ($node instanceof Node\Stmt\Use_) {
                 return null;
             }
@@ -1035,7 +1042,7 @@ CODE_SAMPLE
 
             $phpDocNodeTraverser = new PhpDocParser\PhpDocParser\PhpDocNodeTraverser();
 
-            $phpDocNodeTraverser->traverseWithCallable($phpDocInfo->getPhpDocNode(), '', static function (Ast\Node $phpDocNode) use ($aliasesToReferences, $containerNode, $namespacePrefix, $moreSpecificNamespacePrefixes, $namespacePrefixOfContainingFile, &$hasChanged): ?Ast\Type\IdentifierTypeNode {
+            $phpDocNodeTraverser->traverseWithCallable($phpDocInfo->getPhpDocNode(), '', static function (Ast\Node $phpDocNode) use ($aliasesToReferences, $classReferences, $containerNode, $namespacePrefix, $moreSpecificNamespacePrefixes, $namespacePrefixOfContainingFile, &$hasChanged): ?Ast\Type\IdentifierTypeNode {
                 if (!$phpDocNode instanceof Ast\Type\IdentifierTypeNode) {
                     return null;
                 }
@@ -1087,14 +1094,20 @@ CODE_SAMPLE
 
                 if (!\array_key_exists($firstName, $aliasesToReferences)) {
                     if (
-                        \count($nameParts) < 2
-                        || !$containerNode instanceof Node\Stmt\Namespace_
+                        !$containerNode instanceof Node\Stmt\Namespace_
                         || null === $containerNode->name
                     ) {
                         return null;
                     }
 
                     $fullyQualifiedName = $containerNode->name->toString() . '\\' . $phpDocNode->name;
+
+                    if (
+                        \count($nameParts) < 2
+                        && !\array_key_exists($fullyQualifiedName, $classReferences)
+                    ) {
+                        return null;
+                    }
 
                     $reference = Rules\Files\Reference::fromString($fullyQualifiedName);
 
@@ -1622,6 +1635,35 @@ CODE_SAMPLE
                 $discovered[$childKey] = $childPrefix;
             }
         }
+    }
+
+    /**
+     * @param list<Node\Stmt> $statements
+     *
+     * @return array<string, true>
+     */
+    private static function fullyQualifiedReferences(array $statements): array
+    {
+        $nodeFinder = new NodeFinder();
+
+        $functionAndConstantNodeIdentifiers = self::functionAndConstantNodeIdentifiers($statements);
+
+        $nodes = $nodeFinder->find($statements, static function (Node $node) use ($functionAndConstantNodeIdentifiers): bool {
+            if (!$node instanceof Node\Name\FullyQualified) {
+                return false;
+            }
+
+            return !\in_array(\spl_object_id($node), $functionAndConstantNodeIdentifiers, true);
+        });
+
+        $references = [];
+
+        foreach ($nodes as $node) {
+            /** @var Node\Name\FullyQualified $node */
+            $references[$node->toString()] = true;
+        }
+
+        return $references;
     }
 
     /**

--- a/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithDiscoverNamespacePrefixesAndForceRelativeReferencesAndParentNamespacePrefixes/file-references-unimported-sibling-by-short-name-in-docblock.php.inc
+++ b/test/Fixture/Files/ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector/WithDiscoverNamespacePrefixesAndForceRelativeReferencesAndParentNamespacePrefixes/file-references-unimported-sibling-by-short-name-in-docblock.php.inc
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Catalog\Product\Listing;
+
+final class ProductListing
+{
+    /**
+     * @var list<ProductSummary>
+     */
+    private array $items;
+
+    /**
+     * @param ProductSummary $item
+     * @param int $index
+     * @param array{price: Price, index: int} $shape
+     *
+     * @return self
+     */
+    public function with(ProductSummary $item, int $index, array $shape): self
+    {
+        return $this;
+    }
+
+    public function total(): \App\Catalog\Product\Listing\Price
+    {
+        return \App\Catalog\Product\Listing\Price::sum();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace App\Catalog\Product\Listing;
+
+use App\Catalog;
+final class ProductListing
+{
+    /**
+     * @var list<Catalog\Product\Listing\ProductSummary>
+     */
+    private array $items;
+
+    /**
+     * @param Catalog\Product\Listing\ProductSummary $item
+     * @param int $index
+     * @param array{price: Catalog\Product\Listing\Price, index: int} $shape
+     *
+     * @return self
+     */
+    public function with(Catalog\Product\Listing\ProductSummary $item, int $index, array $shape): self
+    {
+        return $this;
+    }
+
+    public function total(): Catalog\Product\Listing\Price
+    {
+        return Catalog\Product\Listing\Price::sum();
+    }
+}
+
+?>


### PR DESCRIPTION
This pull request

- [x] references namespaced symbols in doc blocks consistently with code
- [x] adjusts `ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector` to reference namespaced symbols in doc blocks consistently with code
- [x] runs `make refactoring`